### PR TITLE
fix: expired auctions in basket crash ui

### DIFF
--- a/src/components/based/AuctionDataTable/AuctionDataCampaignCell.tsx
+++ b/src/components/based/AuctionDataTable/AuctionDataCampaignCell.tsx
@@ -11,7 +11,7 @@ export interface ICampaignCell {
   id: number;
 }
 
-const AuctionDataCampaingCell: FC<ICampaignCell> = ({
+const AuctionDataCampaignCell: FC<ICampaignCell> = ({
   align,
   status,
   campaignUris,
@@ -38,4 +38,4 @@ const AuctionDataCampaingCell: FC<ICampaignCell> = ({
   );
 };
 
-export default AuctionDataCampaingCell;
+export default AuctionDataCampaignCell;

--- a/src/components/based/AuctionDataTable/index.tsx
+++ b/src/components/based/AuctionDataTable/index.tsx
@@ -21,7 +21,7 @@ import {
   Navigation,
   NavigationButton,
 } from './styles';
-import AuctionDataCampaingCell from './AuctionDataCampaingCell';
+import AuctionDataCampaignCell from './AuctionDataCampaignCell';
 import { useTheme } from '@mui/styles';
 import Image from 'next/image';
 import { addAuction, removeAuctionById } from '@/lib/redux/auctionBasketSlice';
@@ -446,12 +446,12 @@ const DataTable: React.FC<Props> = ({ isCreator, auctions, name, format }) => {
                     {row.contractStartTime}
                   </TableBodyCell>
                   <TableBodyCell align="left">{`${row.duration}`}</TableBodyCell>
-                  <AuctionDataCampaingCell
+                  <AuctionDataCampaignCell
                     align="left"
                     status={row.status}
                     campaignUris={campaignUris}
                     id={row.campaign}
-                  ></AuctionDataCampaingCell>
+                  ></AuctionDataCampaignCell>
                   <TableBodyCell align="left">
                     <b>{row.price.toFixed(2)}</b>USDC
                   </TableBodyCell>

--- a/src/components/based/AuctionDataTable/index.tsx
+++ b/src/components/based/AuctionDataTable/index.tsx
@@ -478,7 +478,7 @@ const DataTable: React.FC<Props> = ({ isCreator, auctions, name, format }) => {
                           onClick={() =>
                             dispatch(
                               addAuction({
-                                ...row,
+                                ...getSellerAuctionForBasketFromId(row.id),
                                 name,
                                 format,
                               }),

--- a/src/components/based/CartPreview/AuctionRow.tsx
+++ b/src/components/based/CartPreview/AuctionRow.tsx
@@ -5,7 +5,7 @@ import { removeAuctionById } from '@/lib/redux/auctionBasketSlice';
 import { useDispatch } from 'react-redux';
 import {
   calculatePrice,
-  getAuctionDuration,
+  getContractDuration,
   getAuctionStartsIn,
 } from '@/utils/classes/Auction';
 
@@ -84,7 +84,7 @@ export default function AuctionRow({ auctionData }: { auctionData: any }) {
     contractTimeEnd,
     priceStart,
   ).toFixed(2);
-  const duration = getAuctionDuration(contractTimeStart, contractTimeEnd);
+  const duration = getContractDuration(contractTimeStart, contractTimeEnd);
 
   return (
     <Wrapper>

--- a/src/pages/review-order.tsx
+++ b/src/pages/review-order.tsx
@@ -47,7 +47,7 @@ import _ from 'lodash';
 import { useRouter } from 'next/router';
 import {
   calculatePrice,
-  getAuctionDuration,
+  getContractDuration,
   getAuctionStartsIn,
 } from '@/utils/classes/Auction';
 
@@ -441,7 +441,7 @@ const ReviewOrderPage = () => {
                           <TableBodyCell align="left">
                             {getAuctionStartsIn(row.contractTimeStart)}
                           </TableBodyCell>
-                          <TableBodyCell align="left">{`${getAuctionDuration(
+                          <TableBodyCell align="left">{`${getContractDuration(
                             row.contractTimeStart,
                             row.contractTimeEnd,
                           )}`}</TableBodyCell>

--- a/src/utils/classes/Auction.ts
+++ b/src/utils/classes/Auction.ts
@@ -134,8 +134,8 @@ export const calculatePrice = function (
   return Number(formatUnits(price, 6));
 };
 
-export const hasAuctionEnded = function (contractTimeEnd: string): boolean {
-  return Number(contractTimeEnd) <= getCurrentTime();
+export const hasAuctionEnded = function (auctionTimeEnd: string): boolean {
+  return Number(auctionTimeEnd) <= getCurrentTime();
 };
 
 export default class Auction {

--- a/src/utils/classes/Auction.ts
+++ b/src/utils/classes/Auction.ts
@@ -127,9 +127,9 @@ export const calculatePrice = function (
 ) {
   const price = calcPrice(
     BigNumber.from(getCurrentTime()),
-    BigNumber.from(auctionTimeStart),
-    BigNumber.from(contractTimeEnd),
-    BigNumber.from(priceStart),
+    BigNumber.from(auctionTimeStart || 0),
+    BigNumber.from(contractTimeEnd || 0),
+    BigNumber.from(priceStart || 0),
   );
   return Number(formatUnits(price, 6));
 };

--- a/src/utils/classes/Auction.ts
+++ b/src/utils/classes/Auction.ts
@@ -80,7 +80,7 @@ const getCurrentTime = function (): number {
   return Number((Date.now() / 1000).toFixed(0));
 };
 
-export const getAuctionDuration = function (
+export const getContractDuration = function (
   contractTimeStart: string,
   contractTimeEnd: string,
 ): string {
@@ -230,7 +230,7 @@ export default class Auction {
   }
 
   contractDuration(): string {
-    return getAuctionDuration(
+    return getContractDuration(
       this.sellerAuction.contractTimeStart,
       this.sellerAuction.contractTimeEnd,
     );

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -19,6 +19,11 @@ export function calcPrice(
   const timePassed = timeNow.sub(timeStart);
   const timeTotal = timeEndToken.sub(timeStart);
   const reStartPrice = startPrice.mul(100000);
+
+  // return 0 if timeTotal is 0
+  if (timeTotal.eq(BigNumber.from(0))) {
+    return BigNumber.from(0);
+  }
   const gradient = reStartPrice.div(timeTotal);
   const bidPrice = reStartPrice.sub(gradient.mul(timePassed)).div(100000);
 


### PR DESCRIPTION
Changes:
1. Refactor `AuctionDataCampaingCell` to `AuctionDataCampaignCell`
2. Stale expired items in basket can crash ui. Right now the temporary fix is to allow for undefined values in the `calculatePrice` and `calcPrice` function. A better solution would be to dynamically update the basket removing expired auctions.