### PR TITLE
fix: routes for campaigns

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,7 +14,7 @@ const noAuthRoutes = new Set([
   `/`,
   `/space/[id]`,
   `/space/[id]/new-auction`,
-  `/campaigns/[id]`,
+  `/campaign/[id]`,
   `/auth/discord/[id]`,
   `/[id]`,
 ]);

--- a/src/components/based/AuctionDataTable/AuctionDataCampaignCell.tsx
+++ b/src/components/based/AuctionDataTable/AuctionDataCampaignCell.tsx
@@ -30,7 +30,7 @@ const AuctionDataCampaignCell: FC<ICampaignCell> = ({
       status === AUCTION_STATUS.active ||
       status === AUCTION_STATUS.bought ||
       status === AUCTION_STATUS.finished ? (
-        <Link href={`/campaigns/${id}?chainId=${chainId}`}>{name}</Link>
+        <Link href={`/campaign/${id}?chainId=${chainId}`}>{name}</Link>
       ) : (
         `None`
       )}


### PR DESCRIPTION
Changes:
There's a naming typo in campaigns that prevented campaigns from being viewed without a wallet.
This PR fixes the typo

Related to issue #107 